### PR TITLE
openapi.yamlに/ws/hit-judgeのPlayerInput・HitResult・Warningスキーマを正式定義

### DIFF
--- a/docs/03_design/api/openapi.yaml
+++ b/docs/03_design/api/openapi.yaml
@@ -473,11 +473,11 @@ components:
       discriminator:
         propertyName: presetId
         mapping:
-          rainbow: '#/components/schemas/RainbowParams'
-          flash:   '#/components/schemas/FlashParams'
-          wave:    '#/components/schemas/WaveParams'
-          sparkle: '#/components/schemas/SparkleParams'
-          blur:    '#/components/schemas/BlurParams'
+          rainbow: '#/components/schemas/EffectPresetMessage/oneOf/0'
+          flash:   '#/components/schemas/EffectPresetMessage/oneOf/1'
+          wave:    '#/components/schemas/EffectPresetMessage/oneOf/2'
+          sparkle: '#/components/schemas/EffectPresetMessage/oneOf/3'
+          blur:    '#/components/schemas/EffectPresetMessage/oneOf/4'
       example:
         schemaVersion: "1.0"
         presetId: "rainbow"


### PR DESCRIPTION
openapi.yamlにEffectPresetMessageのプリセット固有パラメータ詳細（型・必須/任意・範囲・デフォルト値）を追記

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビジュアルエフェクトプリセットごとに、詳細なパラメータ設定ができるようになりました（レインボー、フラッシュ、ウェーブ、スパークル、ブラー）。
  * リアルタイム判定用のWebSocketイベント（プレイヤー入力、判定結果、警告）のメッセージ形式が追加されました。

* **ドキュメント**
  * API仕様書に新しいエフェクトプリセットおよびWebSocketイベントのスキーマ情報を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->