### PR TITLE
Feat/test 20250731

### DIFF
--- a/docs/03_design/api/openapi.yaml
+++ b/docs/03_design/api/openapi.yaml
@@ -289,6 +289,7 @@ paths:
       parameters:
         - name: id
           in: path
+          required: true
           schema:
             type: string
             format: uuid

--- a/docs/05_test/strategy.md
+++ b/docs/05_test/strategy.md
@@ -36,12 +36,14 @@ All tests will be executed automatically on every pull request to the `develop` 
 
 ## 5. WebSocket Testing
 
-Our strategy for testing WebSocket endpoints is as follows:
+Our strategy for testing WebSocket endpoints is to **prioritize contract testing** to ensure message integrity and adherence to the OpenAPI specification.
 
-- **/ws/hit-judge**: An integration test will be implemented in `tests/integration/` to verify the connection lifecycle and the real-time message flow. This includes sending `PlayerInput` messages and asserting the reception of `HitResult` or `Warning` messages based on the specifications found in the sequence diagrams.
-- **/ws/effectPreset**: A contract test will be created in `tests/contract/` to validate that messages pushed from the server conform to the `EffectPresetMessage` schema defined in `openapi.yaml`. This test will subscribe to the WebSocket and validate incoming messages against the schema.
+- **/ws/hit-judge**: A contract test has been implemented in `tests/contract/test_websocket_contract.py`. It validates that both sent (`PlayerInput`) and received (`HitResult`, `Warning`) messages conform to their respective schemas in `openapi.yaml`.
+- **/ws/effectPreset**: A contract test has been implemented in `tests/contract/test_websocket_contract.py`. It validates that messages pushed from the server conform to the `EffectPresetMessage` schema, which now includes detailed, per-preset parameter validation using a `discriminator`.
+
+These contract tests require a running WebSocket server (or a mock equivalent) to be executed in the CI pipeline.
 
 ## 6. Open Questions
 
-- (Resolved) The schema for `/ws/effectPreset` is now defined in `openapi.yaml` as `EffectPresetMessage`.
-- The specific parameters for each `presetId` (e.g., `hueShift` for `rainbow`) are listed as examples in `EffectPresetParams`. A more formal, machine-readable definition for each preset's parameters would further improve test accuracy and prevent invalid parameter combinations. This should be discussed with the design team.
+- **(Resolved)** The schema for `/ws/effectPreset` is now defined in `openapi.yaml` with a `discriminator` to enforce per-preset parameters, resolving the previous ambiguity.
+- **(Resolved)** The schemas for `/ws/hit-judge` (`PlayerInput`, `HitResult`, `Warning`) have been formally defined in `openapi.yaml`, enabling contract testing.

--- a/docs/05_test/strategy.md
+++ b/docs/05_test/strategy.md
@@ -36,14 +36,18 @@ All tests will be executed automatically on every pull request to the `develop` 
 
 ## 5. WebSocket Testing
 
-Our strategy for testing WebSocket endpoints is to **prioritize contract testing** to ensure message integrity and adherence to the OpenAPI specification.
+Our strategy for testing WebSocket endpoints combines **contract testing** for message integrity and **integration testing** for interaction flows.
 
-- **/ws/hit-judge**: A contract test has been implemented in `tests/contract/test_websocket_contract.py`. It validates that both sent (`PlayerInput`) and received (`HitResult`, `Warning`) messages conform to their respective schemas in `openapi.yaml`.
-- **/ws/effectPreset**: A contract test has been implemented in `tests/contract/test_websocket_contract.py`. It validates that messages pushed from the server conform to the `EffectPresetMessage` schema, which now includes detailed, per-preset parameter validation using a `discriminator`.
+- **Contract Tests (`tests/contract/test_websocket_contract.py`)**:
+  - These tests are now **active** in the CI pipeline.
+  - They validate that all WebSocket messages (`PlayerInput`, `HitResult`, `Warning`, `EffectPresetMessage`) strictly adhere to the `openapi.yaml` schemas.
+  - The test for `EffectPresetMessage` correctly interprets the `discriminator` to enforce per-preset parameter requirements.
+- **Integration Tests (`tests/integration/test_websocket_interaction.py`)**:
+  - A new test layer to verify the request/response correlation.
+  - For example, it ensures that when a `PlayerInput` is sent to `/ws/hit-judge`, a valid `HitResult` or `Warning` is received in response.
 
-These contract tests require a running WebSocket server (or a mock equivalent) to be executed in the CI pipeline.
+These tests require a running WebSocket server (or a mock equivalent) to be executed in the CI pipeline.
 
 ## 6. Open Questions
 
-- **(Resolved)** The schema for `/ws/effectPreset` is now defined in `openapi.yaml` with a `discriminator` to enforce per-preset parameters, resolving the previous ambiguity.
-- **(Resolved)** The schemas for `/ws/hit-judge` (`PlayerInput`, `HitResult`, `Warning`) have been formally defined in `openapi.yaml`, enabling contract testing.
+- **CI Setup for WebSocket Tests**: How should the test WebSocket server be managed in the CI environment (e.g., via Docker Compose, a background process, or a mock server library) to ensure these new contract and integration tests run reliably?

--- a/docs/05_test/strategy.md
+++ b/docs/05_test/strategy.md
@@ -9,7 +9,7 @@ This document outlines the testing strategy for the "PlayAsYouLike" project. Our
 | Layer | Tool / Framework | Location | Purpose |
 | :--- | :--- | :--- | :--- |
 | **Acceptance (E2E)** | Gherkin (Cucumber/Behave) | `tests/e2e/` | **Validate user requirements (USDM)**. Simulates user behavior from the outside-in, ensuring the system delivers the expected value. |
-| **Contract** | Schemathesis | `tests/contract/` | **Verify API contracts**. Automatically validates that the API implementation adheres to the `openapi.yaml` specification, preventing breaking changes between consumer and provider. |
+| **Contract** | Schemathesis, Pytest | `tests/contract/` | **Verify API contracts**. Automatically validates that the API implementation adheres to the `openapi.yaml` specification, including WebSocket message schemas. |
 | **Integration** | Pytest | `tests/integration/` | Test interactions between components (e.g., API server and database, service to service, **WebSocket communication**). |
 | **Unit** | Pytest | `tests/unit/` | Test individual functions, methods, or classes in isolation. Fast feedback for developers. |
 
@@ -20,7 +20,8 @@ Our initial coverage goals are as follows. These will be measured and reported v
 - **USDM Acceptance Criteria Coverage**: 100%
   - Every leaf-node requirement in `docs/02_requirements/usdm/` must have at least one corresponding Gherkin scenario in `tests/e2e/`.
 - **API Contract Coverage**: 100%
-  - All HTTP endpoints and methods defined in `openapi.yaml` will be tested by Schemathesis. WebSocket endpoints require separate integration tests.
+  - All HTTP endpoints and methods defined in `openapi.yaml` will be tested by Schemathesis.
+  - All WebSocket message schemas (e.g., `EffectPresetMessage`) will be validated via dedicated contract tests.
 - **Code Coverage (Unit & Integration)**: > 80%
   - This is a target for the development team to maintain.
 
@@ -38,8 +39,9 @@ All tests will be executed automatically on every pull request to the `develop` 
 Our strategy for testing WebSocket endpoints is as follows:
 
 - **/ws/hit-judge**: An integration test will be implemented in `tests/integration/` to verify the connection lifecycle and the real-time message flow. This includes sending `PlayerInput` messages and asserting the reception of `HitResult` or `Warning` messages based on the specifications found in the sequence diagrams.
-- **/ws/effectPreset**: Testing for this endpoint is currently blocked. The specific schema for the pushed `effectPreset {presetId, params}` message needs to be clarified in the design documents before a valid test can be created.
+- **/ws/effectPreset**: A contract test will be created in `tests/contract/` to validate that messages pushed from the server conform to the `EffectPresetMessage` schema defined in `openapi.yaml`. This test will subscribe to the WebSocket and validate incoming messages against the schema.
 
 ## 6. Open Questions
 
-- The specific schema for messages pushed from the `/ws/effectPreset` endpoint (e.g., `effectPreset {presetId, params}`) needs to be defined in the design documents to enable test creation.
+- (Resolved) The schema for `/ws/effectPreset` is now defined in `openapi.yaml` as `EffectPresetMessage`.
+- The specific parameters for each `presetId` (e.g., `hueShift` for `rainbow`) are listed as examples in `EffectPresetParams`. A more formal, machine-readable definition for each preset's parameters would further improve test accuracy and prevent invalid parameter combinations. This should be discussed with the design team.

--- a/tests/contract/test_websocket_contract.py
+++ b/tests/contract/test_websocket_contract.py
@@ -4,30 +4,48 @@ import jsonschema
 from websocket import create_connection
 from urllib.parse import urljoin
 import yaml
+import time
 
 # --- Test Configuration ---
 BASE_URL = "ws://api.playasul.local"
 OPENAPI_PATH = "docs/03_design/api/openapi.yaml"
 
-@pytest.fixture(scope="module")
-def effect_preset_schema():
-    """OpenAPIファイルからEffectPresetMessageスキーマをロードする"""
-    with open(OPENAPI_PATH, 'r') as f:
-        openapi_spec = yaml.safe_load(f)
-    schema = openapi_spec["components"]["schemas"]["EffectPresetMessage"]
-    
-    # $refを解決するために、完全な仕様をリゾルバに渡す
-    resolver = jsonschema.RefResolver.from_schema(openapi_spec)
-    
-    return schema, resolver
+# --- Fixtures ---
 
-@pytest.mark.skip(reason="This test requires a running WebSocket server that pushes messages.")
-def test_effect_preset_message_contract(effect_preset_schema):
+@pytest.fixture(scope="module")
+def openapi_spec():
+    """OpenAPIファイルをロードして返す"""
+    with open(OPENAPI_PATH, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+@pytest.fixture(scope="module")
+def schema_resolver(openapi_spec):
+    """$refを解決するためのリゾルバを提供する"""
+    return jsonschema.RefResolver.from_schema(openapi_spec)
+
+@pytest.fixture(scope="module")
+def effect_preset_schema(openapi_spec):
+    """EffectPresetMessageスキーマを返す"""
+    return openapi_spec["components"]["schemas"]["EffectPresetMessage"]
+
+@pytest.fixture(scope="module")
+def hit_judge_schemas(openapi_spec):
+    """Hit Judge関連のスキーマを返す"""
+    schemas = openapi_spec["components"]["schemas"]
+    return {
+        "PlayerInput": schemas["PlayerInput"],
+        "HitResult": schemas["HitResult"],
+        "Warning": schemas["Warning"],
+    }
+
+# --- Test Cases ---
+
+# @pytest.mark.skip(reason="This test requires a running WebSocket server that pushes messages.")
+def test_effect_preset_message_contract(effect_preset_schema, schema_resolver):
     """
     /ws/effectPreset から受信したメッセージが
     OpenAPIで定義されたスキーマに準拠していることを検証する。
     """
-    schema, resolver = effect_preset_schema
     ws_url = urljoin(BASE_URL, "/ws/effectPreset")
     
     try:
@@ -38,8 +56,51 @@ def test_effect_preset_message_contract(effect_preset_schema):
         message = json.loads(message_str)
         
         # スキーマ検証
-        jsonschema.validate(instance=message, schema=schema, resolver=resolver)
+        jsonschema.validate(instance=message, schema=effect_preset_schema, resolver=schema_resolver)
         
+    except TimeoutError:
+        pytest.fail("WebSocket connection timed out. No message received from server.")
+    except Exception as e:
+        pytest.fail(f"An error occurred: {e}")
+    finally:
+        if 'ws' in locals() and ws.connected:
+            ws.close()
+
+# @pytest.mark.skip(reason="This test requires a running WebSocket server that responds to inputs.")
+def test_hit_judge_message_contract(hit_judge_schemas, schema_resolver):
+    """
+    /ws/hit-judge との送受信メッセージが
+    OpenAPIで定義されたスキーマに準拠していることを検証する。
+    """
+    ws_url = urljoin(BASE_URL, "/ws/hit-judge")
+    
+    # テスト用の入力データ
+    player_input = {
+        "timestamp": int(time.time() * 1000),
+        "lane": 1,
+        "action": "hit"
+    }
+    
+    try:
+        ws = create_connection(ws_url, timeout=10)
+        
+        # 1. PlayerInputの送信メッセージを検証
+        jsonschema.validate(instance=player_input, schema=hit_judge_schemas["PlayerInput"], resolver=schema_resolver)
+        ws.send(json.dumps(player_input))
+        
+        # 2. HitResult/Warningの受信メッセージを検証
+        message_str = ws.recv()
+        message = json.loads(message_str)
+        
+        # 受信メッセージがHitResultかWarningのどちらかのスキーマに合致するか検証
+        try:
+            jsonschema.validate(instance=message, schema=hit_judge_schemas["HitResult"], resolver=schema_resolver)
+        except jsonschema.ValidationError:
+            try:
+                jsonschema.validate(instance=message, schema=hit_judge_schemas["Warning"], resolver=schema_resolver)
+            except jsonschema.ValidationError as e:
+                pytest.fail(f"Received message does not match HitResult or Warning schema: {e}")
+
     except TimeoutError:
         pytest.fail("WebSocket connection timed out. No message received from server.")
     except Exception as e:

--- a/tests/contract/test_websocket_contract.py
+++ b/tests/contract/test_websocket_contract.py
@@ -40,12 +40,15 @@ def effect_preset_schema(openapi_spec):
 @pytest.fixture(scope="module")
 def hit_judge_schemas(openapi_spec):
     """Hit Judge関連のスキーマを返す"""
-    schemas = openapi_spec["components"]["schemas"]
-    return {
-        "PlayerInput": schemas["PlayerInput"],
-        "HitResult":  schemas["HitResult"],
-        "Warning":    schemas["Warning"],
-    }
+    try:
+        schemas = openapi_spec["components"]["schemas"]
+        return {
+            "PlayerInput": schemas["PlayerInput"],
+            "HitResult":  schemas["HitResult"],
+            "Warning":    schemas["Warning"],
+        }
+    except KeyError as e:
+        pytest.fail(f"Required schema not found in OpenAPI spec: {e}")
 
 # --- Test Cases ---
 

--- a/tests/contract/test_websocket_contract.py
+++ b/tests/contract/test_websocket_contract.py
@@ -1,0 +1,49 @@
+import pytest
+import json
+import jsonschema
+from websocket import create_connection
+from urllib.parse import urljoin
+import yaml
+
+# --- Test Configuration ---
+BASE_URL = "ws://api.playasul.local"
+OPENAPI_PATH = "docs/03_design/api/openapi.yaml"
+
+@pytest.fixture(scope="module")
+def effect_preset_schema():
+    """OpenAPIファイルからEffectPresetMessageスキーマをロードする"""
+    with open(OPENAPI_PATH, 'r') as f:
+        openapi_spec = yaml.safe_load(f)
+    schema = openapi_spec["components"]["schemas"]["EffectPresetMessage"]
+    
+    # $refを解決するために、完全な仕様をリゾルバに渡す
+    resolver = jsonschema.RefResolver.from_schema(openapi_spec)
+    
+    return schema, resolver
+
+@pytest.mark.skip(reason="This test requires a running WebSocket server that pushes messages.")
+def test_effect_preset_message_contract(effect_preset_schema):
+    """
+    /ws/effectPreset から受信したメッセージが
+    OpenAPIで定義されたスキーマに準拠していることを検証する。
+    """
+    schema, resolver = effect_preset_schema
+    ws_url = urljoin(BASE_URL, "/ws/effectPreset")
+    
+    try:
+        ws = create_connection(ws_url, timeout=10)
+        
+        # サーバーからのメッセージを1つ待つ
+        message_str = ws.recv()
+        message = json.loads(message_str)
+        
+        # スキーマ検証
+        jsonschema.validate(instance=message, schema=schema, resolver=resolver)
+        
+    except TimeoutError:
+        pytest.fail("WebSocket connection timed out. No message received from server.")
+    except Exception as e:
+        pytest.fail(f"An error occurred: {e}")
+    finally:
+        if 'ws' in locals() and ws.connected:
+            ws.close()

--- a/tests/e2e/US-002.feature
+++ b/tests/e2e/US-002.feature
@@ -28,3 +28,15 @@ Feature: US-002 URL から曲情報を取得しプレイ準備できる
     When ユーザが10分を超える動画のURLを入力し「Fetch」を押す
     Then 「10分を超える部分は自動的にカットして再生します」という警告が表示される
     And 「Play」ボタンは有効になる
+
+  Scenario: 短縮形式の有効なURLでメタデータが表示される
+    Given トップページでURL入力フォームが表示されている
+    When ユーザが有効なYouTube短縮URL "https://youtu.be/3bhr4-pV2f4" を入力し「Fetch」を押す
+    Then 3秒以内に動画タイトルと再生時間が表示される
+    And 「Play」ボタンが有効になる
+
+  Scenario: 非常に長い文字列のURLでエラーメッセージが表示される
+    Given トップページでURL入力フォームが表示されている
+    When ユーザが500文字の無効なURL文字列を入力し「Fetch」を押す
+    Then エラーメッセージ "URLが長すぎます" が表示される
+    And 「Play」ボタンは無効のままである

--- a/tests/integration/test_state_transitions.py
+++ b/tests/integration/test_state_transitions.py
@@ -1,0 +1,79 @@
+import pytest
+import requests
+import uuid
+from urllib.parse import urljoin
+
+# --- Test Configuration ---
+BASE_URL = "https://api.playasul.local"
+
+# --- Helper Functions ---
+
+def create_session():
+    """テスト用のセッションを作成し、sessionIdを返すヘルパー関数"""
+    url = urljoin(BASE_URL, "/sessions")
+    payload = {
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "colorHex": "#FFFFFF"
+    }
+    response = requests.post(url, json=payload, verify=False) # ローカルテストのためSSL検証を無効化
+    response.raise_for_status()
+    return response.json()["sessionId"]
+
+# --- Test Cases ---
+
+def test_valid_state_transitions():
+    """
+    セッションの正常な状態遷移 (running -> paused -> running -> ended) をテストする。
+    """
+    session_id = create_session()
+    state_url = urljoin(BASE_URL, f"/sessions/{session_id}/state")
+
+    # 1. Pause the session
+    pause_payload = {"state": "paused", "pausedAt": 12345}
+    response = requests.patch(state_url, json=pause_payload, verify=False)
+    assert response.status_code == 204, "Failed to pause session"
+
+    # 2. Resume the session
+    resume_payload = {"state": "running"}
+    response = requests.patch(state_url, json=resume_payload, verify=False)
+    assert response.status_code == 204, "Failed to resume session"
+
+    # 3. End the session
+    end_payload = {"state": "ended"}
+    response = requests.patch(state_url, json=end_payload, verify=False)
+    assert response.status_code == 204, "Failed to end session"
+
+
+def test_invalid_state_transition_from_ended():
+    """
+    終了済みのセッションに対して状態変更を試みた際に、エラーが返ることをテストする。
+    """
+    session_id = create_session()
+    state_url = urljoin(BASE_URL, f"/sessions/{session_id}/state")
+
+    # 1. End the session first
+    end_payload = {"state": "ended"}
+    response = requests.patch(state_url, json=end_payload, verify=False)
+    assert response.status_code == 204
+
+    # 2. Try to pause the ended session
+    pause_payload = {"state": "paused", "pausedAt": 67890}
+    response = requests.patch(state_url, json=pause_payload, verify=False)
+    assert response.status_code == 422, "Should not be able to pause an ended session"
+    error_data = response.json()
+    assert error_data["code"] == "VALIDATION_ERROR"
+
+
+def test_pause_without_timestamp_fails():
+    """
+    'paused'状態への遷移時に'pausedAt'タイムスタンプがないとエラーになることをテストする。
+    """
+    session_id = create_session()
+    state_url = urljoin(BASE_URL, f"/sessions/{session_id}/state")
+
+    # Try to pause without pausedAt
+    pause_payload = {"state": "paused"}
+    response = requests.patch(state_url, json=pause_payload, verify=False)
+    assert response.status_code == 422, "Pausing should require a timestamp"
+    error_data = response.json()
+    assert error_data["code"] == "VALIDATION_ERROR"

--- a/tests/integration/test_state_transitions.py
+++ b/tests/integration/test_state_transitions.py
@@ -1,6 +1,4 @@
-import pytest
 import requests
-import uuid
 from urllib.parse import urljoin
 
 # --- Test Configuration ---

--- a/tests/integration/test_websocket_interaction.py
+++ b/tests/integration/test_websocket_interaction.py
@@ -1,0 +1,110 @@
+import pytest
+import json
+import time
+from websocket import create_connection
+from urllib.parse import urljoin
+
+# --- Test Configuration ---
+BASE_URL = "ws://api.playasul.local"
+
+# --- Test Cases ---
+
+def test_hit_judge_interaction():
+    """
+    /ws/hit-judge エンドポイントとの基本的なインタラクションをテストする。
+    クライアントが PlayerInput を送信し、サーバーが HitResult または Warning を返すことを確認する。
+    """
+    ws_url = urljoin(BASE_URL, "/ws/hit-judge")
+    
+    player_input = {
+        "timestamp": int(time.time() * 1000),
+        "lane": 2,
+        "action": "hit"
+    }
+
+    try:
+        ws = create_connection(ws_url, timeout=10)
+        
+        # 1. PlayerInput を送信
+        ws.send(json.dumps(player_input))
+        
+        # 2. サーバーからの応答を受信
+        message_str = ws.recv()
+        message = json.loads(message_str)
+        
+        # 3. 応答が HitResult または Warning の構造を持つことを確認
+        # (契約テストほど厳密ではないが、キーの存在で基本的な構造をチェック)
+        is_hit_result = "result" in message and "score" in message
+        is_warning = "type" in message and "message" in message
+        
+        assert is_hit_result or is_warning, f"Received message is not a valid HitResult or Warning: {message}"
+
+    except TimeoutError:
+        pytest.fail("WebSocket connection timed out. No message received from server.")
+    except Exception as e:
+        pytest.fail(f"An error occurred during WebSocket interaction: {e}")
+    finally:
+        if 'ws' in locals() and ws.connected:
+            ws.close()
+
+def test_hit_judge_rapid_fire():
+    """
+    短時間に連続して PlayerInput を送信しても、サーバーが正常に応答を返し続けることをテストする。
+    """
+    ws_url = urljoin(BASE_URL, "/ws/hit-judge")
+    
+    try:
+        ws = create_connection(ws_url, timeout=10)
+        
+        for i in range(10):
+            player_input = {
+                "timestamp": int(time.time() * 1000) + i * 10,
+                "lane": i % 4,
+                "action": "hit"
+            }
+            ws.send(json.dumps(player_input))
+        
+        # 10回分の応答を受信する
+        for _ in range(10):
+            message_str = ws.recv()
+            message = json.loads(message_str)
+            is_hit_result = "result" in message and "score" in message
+            is_warning = "type" in message and "message" in message
+            assert is_hit_result or is_warning, f"Received message is not a valid HitResult or Warning: {message}"
+
+    except TimeoutError:
+        pytest.fail("WebSocket connection timed out during rapid fire test.")
+    except Exception as e:
+        pytest.fail(f"An error occurred during rapid fire test: {e}")
+    finally:
+        if 'ws' in locals() and ws.connected:
+            ws.close()
+
+def test_hit_judge_invalid_json():
+    """
+    不正な形式のJSONを送信した際に、サーバーが適切に処理することをテストする。
+    (例: Warningを返す、または接続を閉じる)
+    """
+    ws_url = urljoin(BASE_URL, "/ws/hit-judge")
+    invalid_json_string = "this is not a valid json"
+
+    try:
+        ws = create_connection(ws_url, timeout=10)
+        ws.send(invalid_json_string)
+        
+        # サーバーからの応答を待つ
+        # 応答は Warning か、あるいは接続が閉じられることを期待
+        try:
+            message_str = ws.recv()
+            message = json.loads(message_str)
+            assert message.get("type") == "invalid_input", f"Expected an invalid_input warning, but got: {message}"
+        except Exception:
+            # サーバーが接続を閉じた場合、recvはエラーを発生させる
+            # これも期待される動作の一つ
+            assert not ws.connected, "Server should have closed the connection on invalid JSON."
+
+    except Exception as e:
+        pytest.fail(f"An error occurred during invalid JSON test: {e}")
+    finally:
+        if 'ws' in locals() and ws.connected:
+            ws.close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * OpenAPI仕様にて、GET `/replay/{id}` の `id` パスパラメータが必須であることを明記しました。
  * テスト戦略ドキュメントを更新し、PytestとWebSocketメッセージスキーマのコントラクトテストを追加しました。

* **テスト**
  * WebSocketエンドポイントのコントラクトテストを新規追加し、スキーマ準拠を検証します。
  * US-002のE2Eテストに、短縮YouTube URL対応と長すぎるURL入力時のエラー表示シナリオを追加しました。
  * セッション状態遷移の統合テストを追加し、正しい遷移とバリデーションエラーを検証します。
  * `/ws/hit-judge` エンドポイントのWebSocket統合テストを追加し、通常・連続・不正入力時の挙動を確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->