### PR TITLE
feat(frontend): call sessions API for Play (US-003)

### DIFF
--- a/app/api/sessions/route.test.ts
+++ b/app/api/sessions/route.test.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { SessionCreateResponse } from "../../../types/session";
+import { POST } from "./route";
+
+function buildRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/sessions", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+const MOCK_RESPONSE: SessionCreateResponse = {
+  sessionId: "f50e6650-37d2-4d5a-9d8a-472af26886ee",
+  seed: 13579,
+  audioUrl:
+    "https://cdn.playasul.local/audio/f50e6650-37d2-4d5a-9d8a-472af26886ee",
+  beatmap: {
+    bpm: 120,
+    energyEnvelope: [0.1, 0.2],
+    beatTimeline: [0, 500],
+    spectralCentroidSeq: [100, 120],
+    keyProgression: ["Am", "F"],
+    segments: [
+      {
+        label: "Intro",
+        startSec: 0,
+      },
+    ],
+    notes: [
+      {
+        t: 0,
+        lane: 1,
+      },
+    ],
+  },
+  effectsPreset: {
+    id: "preset-1",
+    name: "Azure Bloom",
+    baseColorHex: "#38BDF8",
+  },
+  presets: [],
+};
+
+describe("POST /api/sessions", () => {
+  const originalFetch = global.fetch;
+  const originalOrigin = process.env.PLAY_AS_YOU_LIKE_API_ORIGIN;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.PLAY_AS_YOU_LIKE_API_ORIGIN = originalOrigin;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects invalid payloads with 422", async () => {
+    const request = buildRequest({ url: "not-a-url", colorHex: "#123456" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(422);
+    const payload = (await response.json()) as {
+      code: string;
+      message: string;
+    };
+    expect(payload.code).toBe("INVALID_REQUEST");
+  });
+
+  it("forwards the request to the backend origin and returns its response", async () => {
+    process.env.PLAY_AS_YOU_LIKE_API_ORIGIN = "https://api.playasul.local/v1/";
+
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(MOCK_RESPONSE), {
+        status: 201,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    global.fetch = fetchMock;
+
+    const request = buildRequest({
+      url: " https://www.youtube.com/watch?v=dQw4w9WgXcQ ",
+      colorHex: "#38BDF8",
+    });
+
+    const response = await POST(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
+    expect(targetUrl).toBe("https://api.playasul.local/v1/sessions");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    });
+    expect(init?.body).toBe(
+      JSON.stringify({
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        colorHex: "#38BDF8",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const payload = (await response.json()) as SessionCreateResponse;
+    expect(payload.sessionId).toBe(MOCK_RESPONSE.sessionId);
+  });
+});

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  SessionCreatePayload,
+  SessionCreateResponse,
+} from "../../../types/session";
+
+const DEFAULT_BACKEND_ORIGIN = "http://127.0.0.1:3001";
+
+function normalizeBackendOrigin(): string {
+  const origin =
+    process.env.PLAY_AS_YOU_LIKE_API_ORIGIN?.trim() ?? DEFAULT_BACKEND_ORIGIN;
+
+  return origin.endsWith("/") ? origin.slice(0, -1) : origin;
+}
+
+function isValidUrlCandidate(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isValidColorHex(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^#[0-9A-Fa-f]{6}$/.test(value) &&
+    value.length === 7
+  );
+}
+
+function parseRequestBody(body: unknown): {
+  payload: SessionCreatePayload;
+  error?: string;
+} {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body) ||
+    !("url" in body) ||
+    !("colorHex" in body)
+  ) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "Request body must include url and colorHex.",
+    };
+  }
+
+  const candidateUrl = (body as { url: unknown }).url;
+  const candidateColor = (body as { colorHex: unknown }).colorHex;
+
+  if (!isValidUrlCandidate(candidateUrl)) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "url must be a valid http(s) URL.",
+    };
+  }
+
+  if (!isValidColorHex(candidateColor)) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "colorHex must match #RRGGBB.",
+    };
+  }
+
+  const candidateSeed = (body as { seed?: unknown }).seed;
+  let seed: number | undefined;
+
+  if (typeof candidateSeed === "number" && Number.isFinite(candidateSeed)) {
+    seed = candidateSeed;
+  }
+
+  return {
+    payload: {
+      url: new URL(candidateUrl.trim()).toString(),
+      colorHex: candidateColor,
+      seed,
+    },
+  };
+}
+
+async function forwardToBackend(
+  payload: SessionCreatePayload,
+): Promise<Response> {
+  const origin = normalizeBackendOrigin();
+  return fetch(`${origin}/sessions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+    cache: "no-store",
+  });
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        code: "INVALID_PAYLOAD",
+        message: "Request body must be valid JSON.",
+      },
+      {
+        status: 400,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const { payload, error } = parseRequestBody(body);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        code: "INVALID_REQUEST",
+        message: error,
+      },
+      {
+        status: 422,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await forwardToBackend(payload);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        code: "BACKEND_UNAVAILABLE",
+        message: "Failed to reach session service.",
+        detail: error instanceof Error ? error.message : undefined,
+      },
+      {
+        status: 503,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const contentType = backendResponse.headers.get("content-type") ?? "";
+  const isJsonResponse = contentType.includes("application/json");
+
+  if (!isJsonResponse) {
+    const textBody = await backendResponse.text();
+
+    return NextResponse.json(
+      {
+        code: "BACKEND_PROTOCOL_ERROR",
+        message: "Unexpected response format from session service.",
+        detail: textBody.slice(0, 2000),
+      },
+      {
+        status: 502,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const responsePayload = (await backendResponse.json()) as
+    | SessionCreateResponse
+    | { code: string; message: string; detail?: string };
+
+  return NextResponse.json(responsePayload, {
+    status: backendResponse.status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,256 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  SessionCreatePayload,
+  SessionCreateResponse,
+} from "../../../types/session";
+
+const DEFAULT_BACKEND_ORIGIN = "http://127.0.0.1:3001";
+
+function normalizeBackendOrigin(): string {
+  const origin =
+    process.env.PLAY_AS_YOU_LIKE_API_ORIGIN?.trim() ?? DEFAULT_BACKEND_ORIGIN;
+
+  return origin.endsWith("/") ? origin.slice(0, -1) : origin;
+}
+
+function isValidUrlCandidate(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isValidColorHex(value: unknown): value is string {
+  return typeof value === "string" && /^#[0-9A-Fa-f]{6}$/.test(value);
+}
+
+function parseRequestBody(body: unknown): {
+  payload: SessionCreatePayload;
+  error?: string;
+} {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body) ||
+    !("url" in body) ||
+    !("colorHex" in body)
+  ) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "Request body must include url and colorHex.",
+    };
+  }
+
+  const candidateUrl = (body as { url: unknown }).url;
+  const candidateColor = (body as { colorHex: unknown }).colorHex;
+
+  if (!isValidUrlCandidate(candidateUrl)) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "url must be a valid http(s) URL.",
+    };
+  }
+
+  if (!isValidColorHex(candidateColor)) {
+    return {
+      payload: {
+        url: "",
+        colorHex: "",
+      },
+      error: "colorHex must match #RRGGBB.",
+    };
+  }
+
+  const candidateSeed = (body as { seed?: unknown }).seed;
+  let seed: number | undefined;
+
+  if (
+    typeof candidateSeed === "number" &&
+    Number.isFinite(candidateSeed) &&
+    Number.isInteger(candidateSeed) &&
+    candidateSeed >= 0
+  ) {
+    seed = candidateSeed;
+  }
+
+  return {
+    payload: {
+      url: new URL(candidateUrl.trim()).toString(),
+      colorHex: candidateColor,
+      seed,
+    },
+  };
+}
+
+async function forwardToBackend(
+  payload: SessionCreatePayload,
+): Promise<Response> {
+  const origin = normalizeBackendOrigin();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    return await fetch(`${origin}/sessions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function isValidSessionCreateResponse(
+  payload: unknown,
+): payload is SessionCreateResponse {
+  if (typeof payload !== "object" || payload === null) {
+    return false;
+  }
+
+  const candidate = payload as Partial<SessionCreateResponse>;
+
+  if (
+    typeof candidate.sessionId !== "string" ||
+    typeof candidate.seed !== "number" ||
+    !Number.isFinite(candidate.seed) ||
+    typeof candidate.audioUrl !== "string" ||
+    typeof candidate.beatmap !== "object" ||
+    candidate.beatmap === null ||
+    typeof candidate.effectsPreset !== "object" ||
+    candidate.effectsPreset === null ||
+    !Array.isArray(candidate.presets)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        code: "INVALID_PAYLOAD",
+        message: "Request body must be valid JSON.",
+      },
+      {
+        status: 400,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const { payload, error } = parseRequestBody(body);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        code: "INVALID_REQUEST",
+        message: error,
+      },
+      {
+        status: 422,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await forwardToBackend(payload);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        code: "BACKEND_UNAVAILABLE",
+        message: "Failed to reach session service.",
+        detail: error instanceof Error ? error.message : undefined,
+      },
+      {
+        status: 503,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const contentType = backendResponse.headers.get("content-type") ?? "";
+  const isJsonResponse = contentType.includes("application/json");
+
+  if (!isJsonResponse) {
+    const textBody = await backendResponse.text();
+
+    return NextResponse.json(
+      {
+        code: "BACKEND_PROTOCOL_ERROR",
+        message: "Unexpected response format from session service.",
+        detail: textBody.slice(0, 2000),
+      },
+      {
+        status: 502,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const responsePayload = (await backendResponse.json()) as
+    | SessionCreateResponse
+    | { code: string; message: string; detail?: string };
+
+  if (backendResponse.ok) {
+    if (!isValidSessionCreateResponse(responsePayload)) {
+      return NextResponse.json(
+        {
+          code: "BACKEND_PROTOCOL_ERROR",
+          message: "Backend returned invalid success response shape.",
+        },
+        {
+          status: 502,
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        },
+      );
+    }
+  }
+
+  return NextResponse.json(responsePayload, {
+    status: backendResponse.status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/lib/session-storage.test.ts
+++ b/app/lib/session-storage.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { SessionCreateResponse } from "../../types/session";
+import {
+  LAST_SESSION_STORAGE_KEY,
+  buildStoredSession,
+  clearStoredSession,
+  loadStoredSession,
+  saveStoredSession,
+} from "./session-storage";
+
+const SAMPLE_SESSION: SessionCreateResponse = {
+  sessionId: "c3aa2d73-8d0e-43af-a6e7-1d1b7dfd0b2e",
+  seed: 987654321,
+  audioUrl: "https://cdn.playasul.local/audio/sample?source=foo",
+  beatmap: {
+    bpm: 128,
+    energyEnvelope: [0.1, 0.5, 0.9],
+    beatTimeline: [0, 500, 1000],
+    spectralCentroidSeq: [100, 200, 300],
+    keyProgression: ["C#m", "A", "E"],
+    segments: [
+      {
+        label: "Intro",
+        startSec: 0,
+      },
+    ],
+    notes: [
+      {
+        t: 0,
+        lane: 1,
+      },
+    ],
+  },
+  effectsPreset: {
+    id: "preset-1",
+    name: "Azure Bloom",
+    baseColorHex: "#38BDF8",
+  },
+  presets: [],
+};
+
+function createMockStorage(): Storage {
+  const map = new Map<string, string>();
+
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? (map.get(key) ?? null) : null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+describe("session-storage", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-08-02T12:34:56.000Z"));
+    (globalThis as typeof globalThis & { window?: typeof window }).window = {
+      localStorage: createMockStorage(),
+    } as unknown as typeof window;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: typeof window }).window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("builds a deterministic stored session payload", () => {
+    const stored = buildStoredSession(SAMPLE_SESSION, {
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      colorHex: "#38BDF8",
+    });
+
+    expect(stored).toEqual({
+      sessionId: SAMPLE_SESSION.sessionId,
+      seed: SAMPLE_SESSION.seed,
+      colorHex: "#38BDF8",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      storedAt: "2025-08-02T12:34:56.000Z",
+    });
+  });
+
+  it("persists and restores the latest session", () => {
+    const stored = buildStoredSession(SAMPLE_SESSION, {
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      colorHex: "#38BDF8",
+    });
+
+    saveStoredSession(stored);
+
+    const fromStorage = loadStoredSession();
+    expect(fromStorage).toEqual(stored);
+
+    clearStoredSession();
+    expect(window.localStorage.getItem(LAST_SESSION_STORAGE_KEY)).toBeNull();
+    expect(loadStoredSession()).toBeNull();
+  });
+});

--- a/app/lib/session-storage.test.ts
+++ b/app/lib/session-storage.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { SessionCreateResponse } from "../../types/session";
+import {
+  LAST_SESSION_STORAGE_KEY,
+  buildStoredSession,
+  clearStoredSession,
+  loadStoredSession,
+  saveStoredSession,
+} from "./session-storage";
+
+const SAMPLE_SESSION: SessionCreateResponse = {
+  sessionId: "c3aa2d73-8d0e-43af-a6e7-1d1b7dfd0b2e",
+  seed: 987654321,
+  audioUrl: "https://cdn.playasul.local/audio/sample?source=foo",
+  beatmap: {
+    bpm: 128,
+    energyEnvelope: [0.1, 0.5, 0.9],
+    beatTimeline: [0, 500, 1000],
+    spectralCentroidSeq: [100, 200, 300],
+    keyProgression: ["C#m", "A", "E"],
+    segments: [
+      {
+        label: "Intro",
+        startSec: 0,
+      },
+    ],
+    notes: [
+      {
+        t: 0,
+        lane: 1,
+      },
+    ],
+  },
+  effectsPreset: {
+    id: "preset-1",
+    name: "Azure Bloom",
+    baseColorHex: "#38BDF8",
+  },
+  presets: [],
+};
+
+function createMockStorage(): Storage {
+  const map = new Map<string, string>();
+
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? (map.get(key) ?? null) : null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+describe("session-storage", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-08-02T12:34:56.000Z"));
+    (globalThis as typeof globalThis & { window?: typeof window }).window = {
+      localStorage: createMockStorage(),
+    } as unknown as typeof window;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalWindow) {
+      (globalThis as typeof globalThis & { window?: typeof window }).window =
+        originalWindow;
+    } else {
+      delete (globalThis as typeof globalThis & { window?: typeof window })
+        .window;
+    }
+  });
+
+  it("builds a deterministic stored session payload", () => {
+    const stored = buildStoredSession(SAMPLE_SESSION, {
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      colorHex: "#38BDF8",
+    });
+
+    expect(stored).toEqual({
+      sessionId: SAMPLE_SESSION.sessionId,
+      seed: SAMPLE_SESSION.seed,
+      colorHex: "#38BDF8",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      storedAt: "2025-08-02T12:34:56.000Z",
+    });
+  });
+
+  it("persists and restores the latest session", () => {
+    const stored = buildStoredSession(SAMPLE_SESSION, {
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      colorHex: "#38BDF8",
+    });
+
+    saveStoredSession(stored);
+
+    const fromStorage = loadStoredSession();
+    expect(fromStorage).toEqual(stored);
+
+    clearStoredSession();
+    expect(window.localStorage.getItem(LAST_SESSION_STORAGE_KEY)).toBeNull();
+    expect(loadStoredSession()).toBeNull();
+  });
+});

--- a/app/lib/session-storage.ts
+++ b/app/lib/session-storage.ts
@@ -1,0 +1,91 @@
+import { SessionCreateResponse } from "../../types/session";
+
+export const LAST_SESSION_STORAGE_KEY =
+  "play-as-you-like:last-session:v1:session";
+
+export type StoredSession = {
+  sessionId: string;
+  seed: number;
+  colorHex: string;
+  url: string;
+  storedAt: string;
+};
+
+export function buildStoredSession(
+  payload: SessionCreateResponse,
+  request: { url: string; colorHex: string },
+): StoredSession {
+  return {
+    sessionId: payload.sessionId,
+    seed: payload.seed,
+    colorHex: request.colorHex,
+    url: request.url,
+    storedAt: new Date().toISOString(),
+  };
+}
+
+export function saveStoredSession(session: StoredSession): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      LAST_SESSION_STORAGE_KEY,
+      JSON.stringify(session),
+    );
+  } catch {
+    // localStorage might be unavailable or full; fail silently per UX guidelines.
+  }
+}
+
+export function loadStoredSession(): StoredSession | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(LAST_SESSION_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+
+    if (
+      typeof parsed.sessionId === "string" &&
+      typeof parsed.seed === "number" &&
+      Number.isFinite(parsed.seed) &&
+      Number.isInteger(parsed.seed) &&
+      typeof parsed.colorHex === "string" &&
+      typeof parsed.url === "string"
+    ) {
+      return {
+        sessionId: parsed.sessionId,
+        seed: parsed.seed,
+        colorHex: parsed.colorHex,
+        url: parsed.url,
+        storedAt:
+          typeof parsed.storedAt === "string"
+            ? parsed.storedAt
+            : new Date().toISOString(),
+      };
+    }
+  } catch {
+    // Ignore malformed data and proceed as if no session exists.
+  }
+
+  return null;
+}
+
+export function clearStoredSession(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(LAST_SESSION_STORAGE_KEY);
+  } catch {
+    // Ignore removal errors for consistent UX.
+  }
+}

--- a/app/lib/session-storage.ts
+++ b/app/lib/session-storage.ts
@@ -1,0 +1,90 @@
+import { SessionCreateResponse } from "../../types/session";
+
+export const LAST_SESSION_STORAGE_KEY =
+  "play-as-you-like:last-session:v1:session";
+
+export type StoredSession = {
+  sessionId: string;
+  seed: number;
+  colorHex: string;
+  url: string;
+  storedAt: string;
+};
+
+export function buildStoredSession(
+  payload: SessionCreateResponse,
+  request: { url: string; colorHex: string },
+): StoredSession {
+  return {
+    sessionId: payload.sessionId,
+    seed: payload.seed,
+    colorHex: request.colorHex,
+    url: request.url,
+    storedAt: new Date().toISOString(),
+  };
+}
+
+export function saveStoredSession(session: StoredSession): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      LAST_SESSION_STORAGE_KEY,
+      JSON.stringify(session),
+    );
+  } catch {
+    // localStorage might be unavailable or full; fail silently per UX guidelines.
+  }
+}
+
+export function loadStoredSession(): StoredSession | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(LAST_SESSION_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+
+    if (
+      typeof parsed.sessionId === "string" &&
+      typeof parsed.seed === "number" &&
+      Number.isFinite(parsed.seed) &&
+      typeof parsed.colorHex === "string" &&
+      typeof parsed.url === "string"
+    ) {
+      return {
+        sessionId: parsed.sessionId,
+        seed: parsed.seed,
+        colorHex: parsed.colorHex,
+        url: parsed.url,
+        storedAt:
+          typeof parsed.storedAt === "string"
+            ? parsed.storedAt
+            : new Date().toISOString(),
+      };
+    }
+  } catch {
+    // Ignore malformed data and proceed as if no session exists.
+  }
+
+  return null;
+}
+
+export function clearStoredSession(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(LAST_SESSION_STORAGE_KEY);
+  } catch {
+    // Ignore removal errors for consistent UX.
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,15 @@ import {
   useRef,
   useState,
 } from "react";
+import { SessionCreateResponse } from "../types/session";
+import {
+  buildStoredSession,
+  loadStoredSession,
+  saveStoredSession,
+} from "./lib/session-storage";
 
 export const TUTORIAL_STORAGE_KEY = "play-as-you-like:tutorial-seen:v1";
+const DEFAULT_COLOR_HEX = "#38BDF8";
 
 type UrlMetadata = {
   title: string;
@@ -43,6 +50,7 @@ export default function HomePage() {
   const [metadata, setMetadata] = useState<UrlMetadata | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
+  const [isCreatingSession, setIsCreatingSession] = useState(false);
   const metadataRequestControllerRef = useRef<AbortController | null>(null);
   const latestRequestIdRef = useRef(0);
 
@@ -217,7 +225,90 @@ export default function HomePage() {
     setTutorialOpen(true);
   };
 
-  const isPlayEnabled = Boolean(metadata) && !isFetchingMetadata;
+  const handlePlay = useCallback(async () => {
+    if (!metadata) {
+      return;
+    }
+
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) {
+      setErrorMessage("YouTube の URL を入力してください。");
+      return;
+    }
+
+    const storedSession = loadStoredSession();
+    const payload: {
+      url: string;
+      colorHex: string;
+      seed?: number;
+    } = {
+      url: trimmedUrl,
+      colorHex: DEFAULT_COLOR_HEX,
+    };
+
+    if (storedSession && storedSession.url === trimmedUrl) {
+      payload.seed = storedSession.seed;
+    }
+
+    setIsCreatingSession(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      let body: unknown = null;
+
+      try {
+        body = (await response.json()) as unknown;
+      } catch {
+        body = null;
+      }
+
+      if (!response.ok) {
+        const message =
+          typeof (body as { message?: unknown })?.message === "string"
+            ? (body as { message: string }).message
+            : "セッションの開始に失敗しました。";
+
+        setErrorMessage(message);
+        return;
+      }
+
+      if (
+        typeof (body as { sessionId?: unknown })?.sessionId !== "string" ||
+        typeof (body as { seed?: unknown })?.seed !== "number"
+      ) {
+        setErrorMessage("セッションの開始に失敗しました。");
+        return;
+      }
+
+      const session = body as SessionCreateResponse;
+      saveStoredSession(
+        buildStoredSession(session, {
+          url: payload.url,
+          colorHex: payload.colorHex,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+
+      setErrorMessage("セッションの開始中にエラーが発生しました。");
+    } finally {
+      setIsCreatingSession(false);
+    }
+  }, [metadata, url]);
+
+  const isPlayEnabled =
+    Boolean(metadata) && !isFetchingMetadata && !isCreatingSession;
 
   return (
     <div className="app">
@@ -276,8 +367,9 @@ export default function HomePage() {
                 className="app__primary-action"
                 disabled={!isPlayEnabled}
                 aria-disabled={!isPlayEnabled}
+                onClick={handlePlay}
               >
-                Play
+                {isCreatingSession ? "Starting..." : "Play"}
               </button>
             </div>
             <div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,6 @@ export default function HomePage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
-  const [isCreatingSession, setIsCreatingSession] = useState(false);
   const metadataRequestControllerRef = useRef<AbortController | null>(null);
   const latestRequestIdRef = useRef(0);
   const router = useRouter();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,6 @@ import {
 
 export const TUTORIAL_STORAGE_KEY = "play-as-you-like:tutorial-seen:v1";
 const DEFAULT_COLOR_HEX = "#38BDF8";
-const DEFAULT_COLOR_HEX = "#38BDF8";
 
 type UrlMetadata = {
   title: string;

--- a/types/session.ts
+++ b/types/session.ts
@@ -1,0 +1,43 @@
+export type SessionCreatePayload = {
+  url: string;
+  colorHex: string;
+  seed?: number;
+};
+
+export type BeatmapNote = {
+  t: number;
+  lane: number;
+};
+
+export type BeatmapSegment = {
+  label: string;
+  startSec: number;
+};
+
+export type Beatmap = {
+  bpm: number;
+  energyEnvelope: number[];
+  beatTimeline: number[];
+  spectralCentroidSeq: number[];
+  keyProgression: string[];
+  segments: BeatmapSegment[];
+  notes: BeatmapNote[];
+};
+
+export type VisualEffectPreset = {
+  id: string;
+  name: string;
+  baseColorHex: string;
+  particleIntensity?: number;
+  cameraShake?: number;
+  bgShader?: string;
+};
+
+export type SessionCreateResponse = {
+  sessionId: string;
+  seed: number;
+  beatmap: Beatmap;
+  audioUrl: string;
+  effectsPreset: VisualEffectPreset;
+  presets: VisualEffectPreset[];
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "app/**/*.test.ts?(x)"],
+    pool: "threads",
     reporters: process.env.CI ? ["default"] : ["default"],
     coverage: {
       enabled: false,


### PR DESCRIPTION
close #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セッション作成フローを追加：URL・色・任意のシードでセッションを作成し、作成後にプレイ画面へ遷移します。
  * 作成中は Play ボタンを無効化しラベルを「Starting...」に表示します。
  * ブラウザのローカルストレージへセッションを保存・復元する永続化を追加。
  * バックエンドへの転送と各種検証・エラー応答を導入（可用性・プロトコル検査含む）。

* **テスト**
  * セッション作成ルートとストレージの包括的な自動テストを追加（入力検証、転送挙動、永続化フロー）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->